### PR TITLE
Updated readme for codeclimate 0.85.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### Installation
 
 1. If you haven't already, [install the Code Climate CLI](https://github.com/codeclimate/codeclimate).
-2. Run `codeclimate engines:enable tslint`. This command both installs the engine and enables it in your `.codeclimate.yml` file.
+2. Run `codeclimate engines:install tslint`. This command both installs the engine and enables it in your `.codeclimate.yml` file.
 3. You're ready to analyze! Browse into your project's folder and run `codeclimate analyze`.
 
 ### Need help?


### PR DESCRIPTION
Before.

```
codeclimate engines:enable tslint
unknown command engines:enable
```

After.

```
codeclimate engines:install tslint
Pulling docker images.
Using default tag: latest
latest: Pulling from codeclimate/codeclimate-tslint
Digest: sha256:270e3f918466e718544c8acaadba032a947317e1bc2da7492131e176defdec8b
Status: Image is up to date for codeclimate/codeclimate-tslint:latest
```

I'm using `codeclimate version` **0.85.1**.